### PR TITLE
Renamed API function `check` to `contains` and refactored internals.

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -19,9 +19,9 @@
           unknown_crate_types, warnings)]
 #![deny(deprecated, drop_with_repr_extern, improper_ctypes, missing_docs,
         non_shorthand_field_patterns, overflowing_literals, plugin_as_library,
-        private_no_mangle_fns, private_no_mangle_statics, raw_pointer_derive, stable_features,
-        unconditional_recursion, unknown_lints, unsafe_code, unused, unused_allocation,
-        unused_attributes, unused_comparisons, unused_features, unused_parens, while_true)]
+        private_no_mangle_fns, private_no_mangle_statics, stable_features, unconditional_recursion,
+        unknown_lints, unsafe_code, unused, unused_allocation, unused_attributes,
+        unused_comparisons, unused_features, unused_parens, while_true)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
         unused_qualifications, unused_results, variant_size_differences)]
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
@@ -78,7 +78,6 @@ fn bench_add_10000_1kb_messages_to_1000_capacity(b: &mut ::test::Bencher) {
     assert_eq!(my_cache.len(), 1000);
 }
 
-
 #[bench]
 fn bench_add_1000_1kb_messages_timeout(b: &mut ::test::Bencher) {
     let time_to_live = time::Duration::milliseconds(100);
@@ -90,7 +89,7 @@ fn bench_add_1000_1kb_messages_timeout(b: &mut ::test::Bencher) {
         my_cache.add(generate_random_vec::<u8>(bytes_len));
     }
     let content = generate_random_vec::<u8>(bytes_len);
-    ::std::thread::sleep_ms(100);
+    ::std::thread::sleep(::std::time::Duration::from_millis(100));
 
     b.iter(|| {
         my_cache.add(content.clone());
@@ -101,20 +100,21 @@ fn bench_add_1000_1kb_messages_timeout(b: &mut ::test::Bencher) {
 
 // the following test can not achieve a convergence on performance
 // #[bench]
-// fn bench_add_1000_1MB_msgs_timeout (b: &mut Bencher) {
-//   let time_to_live = time::Duration::milliseconds(100);
-//   let mut my_cache = MessageFilter::<Vec<u8>>::with_expiry_duration(time_to_live);
+// fn bench_add_1000_1mb_messages_timeout (b: &mut ::test::Bencher) {
+//     let time_to_live = time::Duration::milliseconds(100);
+//     let mut my_cache =
+//         ::message_filter::MessageFilter::<Vec<u8>>::with_expiry_duration(time_to_live);
 
-//   let mut contents = Vec::<Vec<u8>>::new();
-//   let bytes_len = 1024 * 1024;
-//   for _ in 0..1000 {
-//     contents.push(generate_random_vec::<u8>(bytes_len));
-//   }
-
-//   b.iter(|| {
-//     for i in 0..1000 {
-//       my_cache.add(contents[i].clone());
+//     let mut contents = Vec::<Vec<u8>>::new();
+//     let bytes_len = 1024 * 1024;
+//     for _ in 0..1000 {
+//         contents.push(generate_random_vec::<u8>(bytes_len));
 //     }
-//   });
-//   b.bytes = 1000 * bytes_len as u64;
+
+//     b.iter(|| {
+//         for i in 0..1000 {
+//             my_cache.add(contents[i].clone());
+//         }
+//     });
+//     b.bytes = 1000 * bytes_len as u64;
 // }


### PR DESCRIPTION
Fixes #49.

If merged, this will require a version increase to 0.2.0.

Also:
- Refactored internals to avoid duplicating container of messages
- Created a test for adding a duplicate message
- Fixed compiler error in benchmark
- Removed deprecated lint check
- Fixed warnings in documentation test

Benchmarks before:

```
test bench_add_10000_1kb_messages_to_1000_capacity ... bench:  17,743,551 ns/iter (+/- 451,948) = 573 MB/s
test bench_add_1000_1kb_messages_timeout           ... bench:     701,435 ns/iter (+/- 493,365) = 1 MB/s
test bench_add_1000_1kb_messages_to_100_capacity   ... bench:   1,768,692 ns/iter (+/- 92,949) = 578 MB/s
```

and after:

```
test bench_add_10000_1kb_messages_to_1000_capacity ... bench:  23,912,992 ns/iter (+/- 632,264) = 419 MB/s
test bench_add_1000_1kb_messages_timeout           ... bench:      19,445 ns/iter (+/- 10,484) = 52 MB/s
test bench_add_1000_1kb_messages_to_100_capacity   ... bench:     245,371 ns/iter (+/- 7,240) = 4172 MB/s
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/message_filter/50)

<!-- Reviewable:end -->
