### PR TITLE
replace time crate with std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.4.0"
 
 [dependencies]
 clippy = {version = "~0.0.63", optional = true}
-time = "~0.1.35"
 
 [dev-dependencies]
 rand = "~0.3.14"

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -35,10 +35,11 @@
 #![cfg_attr(feature="clippy", allow(use_debug))]
 #![feature(test)]
 
-extern crate time;
 extern crate test;
 extern crate rand;
 extern crate message_filter;
+
+use std::time::Duration;
 
 fn generate_random_vec<T>(len: usize) -> Vec<T>
     where T: rand::Rand {
@@ -61,7 +62,7 @@ fn bench_add_1000_1kb_messages_to_100_capacity(b: &mut ::test::Bencher) {
     b.iter(|| {
         for i in 0..1000 {
             // Each value is unique so return from insert is None.
-            let _ = my_cache.insert(contents[i].clone());
+            let _ = my_cache.insert(&contents[i]);
         }
     });
     b.bytes = 1000 * bytes_len as u64;
@@ -80,7 +81,7 @@ fn bench_add_10000_1kb_messages_to_1000_capacity(b: &mut ::test::Bencher) {
     b.iter(|| {
         for i in 0..10000 {
             // Each value is unique so return from insert is None.
-            let _ = my_cache.insert(contents[i].clone());
+            let _ = my_cache.insert(&contents[i]);
         }
     });
     b.bytes = 10000 * bytes_len as u64;
@@ -89,21 +90,21 @@ fn bench_add_10000_1kb_messages_to_1000_capacity(b: &mut ::test::Bencher) {
 
 #[bench]
 fn bench_add_1000_1kb_messages_timeout(b: &mut ::test::Bencher) {
-    let time_to_live = time::Duration::milliseconds(100);
+    let time_to_live = Duration::from_millis(100);
     let mut my_cache =
         ::message_filter::MessageFilter::<Vec<u8>>::with_expiry_duration(time_to_live);
 
     let bytes_len = 1024;
     for _ in 0..1000 {
         // Each value is probably unique so return from insert will probably be None.
-        let _ = my_cache.insert(generate_random_vec::<u8>(bytes_len));
+        let _ = my_cache.insert(&generate_random_vec::<u8>(bytes_len));
     }
     let content = generate_random_vec::<u8>(bytes_len);
-    ::std::thread::sleep(::std::time::Duration::from_millis(100));
+    ::std::thread::sleep(Duration::from_millis(100));
 
     b.iter(|| {
         // Each value is probably unique so return from insert will probably be None.
-        let _ = my_cache.insert(content.clone());
+        let _ = my_cache.insert(&content);
     });
     b.bytes = bytes_len as u64;
     assert_eq!(my_cache.len(), 1);


### PR DESCRIPTION
Affects: Cargo.toml src/lib.rs benches/lib.rs

using std::time instead of the time cate

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/message_filter/63)

<!-- Reviewable:end -->
